### PR TITLE
Modify OS fingerprint feature to use a fingerprint file

### DIFF
--- a/umap-device-fingerprints.json
+++ b/umap-device-fingerprints.json
@@ -1,0 +1,44 @@
+[
+{ "match-names" : ["Apple iPad", "Apple iPhone", "Apple Mac OSX"],
+    "matches" : [
+        { "match-type" : "match-freq", "match-text" : "SetFea", "match-condition" : "__ge__", "match-value" : 1 }
+    ]
+},
+{ "match-names" : ["Generic Linux"],
+    "matches" : [
+        { "match-type" : "match-freq", "match-text" : "GetDes:6:0", "match-condition" : "__ge__", "match-value" : 1 }
+        { "match-type" : "match-freq", "match-text" : "GetDes:3:4", "match-condition" : "__ge__", "match-value" : 1 }
+    ]
+},
+{ "match-names" : ["Microsoft Windows 8"],
+    "matches" : [
+        { "match-type" : "match-freq", "match-text" : "GetDes:3:3", "match-condition" : "__eq__", "match-value" : 2 }
+    ]
+},
+{ "match-names" : ["Sony Playstation 3"],
+    "matches" : [
+        { "match-type" : "match-freq", "match-text" : "GetDes:1:0", "match-condition" : "__eq__", "match-value" : 2 },
+        { "match-type" : "match-freq", "match-text" : "GetDes:2:0", "match-condition" : "__eq__", "match-value" : 2 },
+        { "match-type" : "match-count", "match-condition" : "__eq__", "match-value" : 5 }
+    ]
+},
+{ "match-names" : ["Ubuntu Linux"],
+    "matches" : [
+        { "match-type" : "match-freq", "match-text" : "SetInt", "match-condition" : "__eq__", "match-value" : 2 }
+    ]
+},
+{ "match-names" : ["Brother ADS-2600W scanner"],
+    "matches" : [
+        { "match-type" : "match-freq", "match-text" : "GetDes:1:0", "match-condition" : "__eq__", "match-value" : 2},
+        { "match-type" : "match-freq", "match-text" : "GetDes:2:0", "match-condition" : "__eq__", "match-value" : 4},
+        { "match-type" : "match-count", "match-condition" : "__eq__", "match-value" : 8 }
+    ]
+},
+{ "match-names" : ["AMI BIOS"],
+    "matches" : [
+        { "match-type" : "match-pos", "match-text" : "GetDes:1:0", "match-condition" : "__eq__", "match-value" : 0},
+        { "match-type" : "match-pos", "match-text" : "GetDes:1:0", "match-condition" : "__eq__", "match-value" : 1},
+        { "match-type" : "match-pos", "match-text" : "GetDes:2:0", "match-condition" : "__eq__", "match-value" : 2}
+    ]
+}
+]


### PR DESCRIPTION
This patch modifies umap to use a fingerprint file for its OS matches instead of them being hard-coded in the python file. It uses json file as a convenient file storage format which is easily parseable in python.

Hopefully the format of the fingerprint file is reasonably self-evident. There are three possible match types: _match-freq_ which counts how often a particular message type is in the fingerprint, _match-count_ which counts how many messages are in the fingerprint and _match-pos_ which checks to see if a particular message is at a particular position. The _match-condition_ is the name of any of the inbuilt rich comparison methods documented in the standard python data model. &#95;&#95;lt&#95;&#95;, &#95;&#95;le&#95;&#95;, &#95;&#95;eq&#95;&#95;, &#95;&#95;ne&#95;&#95;, &#95;&#95;gt&#95;&#95; and &#95;&#95;ge&#95;&#95; are the obvious values to put in here.

I also have a huge bundle of other fingerprints to parse. Various cars, Solaris, multiple BSD variants, strange telco equipment and anything else I could find. It would be great to get lots of examples from anyone who has them.
